### PR TITLE
Implement TRDW.XLSX.write()

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1,3 +1,10 @@
+[csv2xlsx]
+git-tree-sha1 = "a21aa47d63275649c2001c9855a8e06e15663887"
+
+    [[csv2xlsx.download]]
+    url = "https://github.com/TuftsCTSI/csv2xlsx/releases/download/v1.1/csv2xlsx.jar.tgz"
+    sha256 = "914ea96b79957e25ed491c157d9d849eefe54395ef03f3398103465e5095fdef"
+
 [CirceR]
 git-tree-sha1 = "85addbe09fadb35c746fc1e05669da35a1613165"
 

--- a/src/TRDW.jl
+++ b/src/TRDW.jl
@@ -37,6 +37,7 @@ include("clarity.jl")
 include("template.jl")
 include("profile.jl")
 include("ohdsi.jl")
+include("xlsx.jl")
 
 include("care_site.jl")
 include("concept.jl")

--- a/src/xlsx.jl
+++ b/src/xlsx.jl
@@ -1,0 +1,11 @@
+module XLSX
+
+"""
+    XLSX.write(file, table; password = nothing)
+
+Write a tabular dataset to an XLSX file, optionally encrypting it.
+"""
+function write
+end
+
+end # module XLSX


### PR DESCRIPTION
This is `csv2xlsx` implemented in Julia with JavaCall. To avoid making TRDW.jl dependent on Java, it is implemented as an optional extension activated on importing of JavaCall.

To use:

1. You must set environment variable `JULIA_COPY_STACKS=1` to run any Julia code that uses JavaCall.
2. Run `]add JavaCall` in Julia shell to add `JavaCall` to your Julia environment.
3. In the source code, you should import JavaCall and initialize it. In Pluto, do both in the same cell:
   ```julia
   begin
       using JavaCall
       JavaCall.init()
   end
   ```
4. Now you can use the function `TRDW.XLSX.write(filename, table; password = "...")`, where `table` is a DataFrame or any Tables.jl-compatible dataset.

Compared to `csv2xlsx`, I enabled formatting for numbers and dates. We could change it or disable it if needed. It would also be easy to pack several datasets into the same XLSX file as separate sheets.