### PR TITLE
Attach and other fixes

### DIFF
--- a/src/define.jl
+++ b/src/define.jl
@@ -238,7 +238,7 @@ function FunSQL.resolve(n::UndefineNode, ctx)
         fields[f] = ft
     end
     n′ = FunSQL.Padding(over = over′)
-    FunSQL.Resolved(FunSQL.RowType(fields), over = n′)
+    FunSQL.Resolved(FunSQL.RowType(fields, t.group), over = n′)
     # FIXME: `select(foo => 1).undefine(foo)`
 end
 

--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -115,6 +115,7 @@ function funsql_group_with(pair::Pair{Symbol, FunSQL.SQLNode}, predicate=true;
         left_join($name => $base, $name.person_id == person_id && $predicate)
         partition($partname.row_number(); order_by = [person_id], name = $partname)
         filter($partname.row_number() <= 1)
+        undefine($name)
     end)
 end
 

--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -119,6 +119,30 @@ function funsql_group_with(pair::Pair{Symbol, FunSQL.SQLNode}, predicate=true;
     end)
 end
 
+function funsql_attach_earliest(pair::Pair{Symbol, FunSQL.SQLNode}, predicate = true)
+    (name, base) = pair
+    partname = gensym()
+    return @funsql begin
+        partition(order_by = [person_id], name = $partname)
+        left_join($name => $base, $name.person_id == person_id && $predicate)
+        partition($partname.row_number(), order_by = [$name.datetime.asc(nulls = last)], name = $partname)
+        filter($partname.row_number() <= 1)
+        undefine($partname)
+    end
+end
+
+function funsql_attach_latest(pair::Pair{Symbol, FunSQL.SQLNode}, predicate = true)
+    (name, base) = pair
+    partname = gensym()
+    return @funsql begin
+        partition(order_by = [person_id], name = $partname)
+        left_join($name => $base, $name.person_id == person_id && $predicate)
+        partition($partname.row_number(), order_by = [$name.datetime.desc(nulls = last)], name = $partname)
+        filter($partname.row_number() <= 1)
+        undefine($partname)
+    end
+end
+
 function funsql_join_with(pair::Pair{Symbol, FunSQL.SQLNode}, predicate=true)
     (name, base) = pair
     return @funsql(join($name => $base, $name.person_id == person_id && $predicate))


### PR DESCRIPTION
- `undefine()`: preserve group type in order not to block aggregates
- `group_with()`: add trailing `undefine(name)` to prohibit direct access to the attached row
- implement `attach_earliest()` and `attach_latest()`, similar to `filter_with()` and `group_with()`

```julia
@funsql begin
	person()
	attach_earliest(
		earliest_bmi => measurement(LOINC("39156-5", "Body mass index (BMI) [Ratio]")))
	attach_latest(
		latest_bmi => measurement(LOINC("39156-5", "Body mass index (BMI) [Ratio]")))
	select(
		person_id,
		earliest_bmi_datetime => earliest_bmi.datetime,
		earliest_bmi_value => earliest_bmi.value_as_number,
		latest_bmi_datetime => latest_bmi.datetime,
		latest_bmi_value => latest_bmi.value_as_number)
end
```

Just like `group_with()` and `filter_with()`, they also accept an optional `predicate` parameter.