### PR TITLE
Make roundup a named argument for demographics()

### DIFF
--- a/src/counting.jl
+++ b/src/counting.jl
@@ -1,6 +1,6 @@
 @funsql begin
 
-demographics(roundup=is_discovery()) = begin
+demographics(; roundup=is_discovery()) = begin
     as(cohort)
     over(
         append(


### PR DESCRIPTION
Currently, demographics() accepts an unnamed argument for roundup, but I think a named argument would be clearer and more consistent. This could be considered breaking, but I can't find any example of passing an unnamed argument in TRDW.jl and ResearchRequests, other than my own.