### PR TITLE
Set driver path in env

### DIFF
--- a/src/connect.jl
+++ b/src/connect.jl
@@ -6,12 +6,13 @@ function connect_to_databricks(; catalog = nothing, schema = nothing)
     DATABRICKS_HTTP_PATH = ENV["DATABRICKS_HTTP_PATH"]
     DATABRICKS_ACCESS_TOKEN = ENV["DATABRICKS_ACCESS_TOKEN"]
     DATABRICKS_CATALOG = get(ENV, "DATABRICKS_CATALOG", "ctsi")
+    ODBC_DRIVER_PATH = get(ENV, "ODBC_DRIVER_PATH", "/opt/simba/spark/lib/64/libsparkodbc_sb64.so")
 
     catalog = something(catalog, DATABRICKS_CATALOG)
     schema = get(ENV, "TRDW_SCHEMA", schema)
-
+    
     DATABRICKS_DSN = build_dsn(
-        Driver = "/opt/simba/spark/lib/64/libsparkodbc_sb64.so",
+        Driver = ODBC_DRIVER_PATH,
         Host = DATABRICKS_SERVER_HOSTNAME,
         Port = 443,
         SSL = 1,

--- a/src/connect.jl
+++ b/src/connect.jl
@@ -10,9 +10,17 @@ function connect_to_databricks(; catalog = nothing, schema = nothing)
 
     catalog = something(catalog, DATABRICKS_CATALOG)
     schema = get(ENV, "TRDW_SCHEMA", schema)
-    
+    driver_paths = [
+        "/opt/simba/spark/lib/64/libsparkodbc_sb64.so",
+        "/Library/simba/spark/lib/libsparkodbc_sb64-universal.dylib"
+    ]
+    driver = driver_paths[findfirst(isfile, driver_paths)]
+    if driver === nothing
+        throw(ErrorException("No valid ODBC driver found in the specified paths."))
+    end
+
     DATABRICKS_DSN = build_dsn(
-        Driver = ODBC_DRIVER_PATH,
+        Driver = driver,
         Host = DATABRICKS_SERVER_HOSTNAME,
         Port = 443,
         SSL = 1,


### PR DESCRIPTION
This small change to TRDW.jl allows one to specify the path to and name of their ODBC driver.

I needed to implement this to work from my mac.